### PR TITLE
Added TimberStream to twig for use directly in a twig file

### DIFF
--- a/includes/class-stream-manager.php
+++ b/includes/class-stream-manager.php
@@ -75,6 +75,7 @@ class StreamManager {
 
 		add_action( 'init', array( $this, 'define_post_types' ), 0 );
 		add_filter('post_updated_messages', array( $this, 'define_post_type_messages' ) );
+		add_filter('get_twig', array($this, 'add_timber_filters_functions'));
 	}
 
 	/**
@@ -214,6 +215,19 @@ class StreamManager {
 			'nopaging'  => true
 		));
 		return $this->streams = Timber::get_posts( $query, $PostClass );
+	}
+
+	function add_timber_filters_functions($twig) {
+		$twig->addFunction(new Twig_SimpleFunction('TimberStream', function ($pid, $StreamClass = 'TimberStream') {
+            if (is_array($pid) && !TimberHelper::is_array_assoc($pid)) {
+                foreach ($pid as &$p) {
+                    $p = new $StreamClass($p);
+                }
+                return $pid;
+            }
+            return new $StreamClass($pid);
+        }));
+        return $twig;
 	}
 
 }


### PR DESCRIPTION
@chrisvoll with this PR you can avoid doing any PHP to retrieve a steam.
### Before:

``` php
$context['job_listings'] = new TimberStream('job-listings');
// the rest as normal...
```

``` html+django
{% for job in job_listings.get_posts %}
    <h3>{{job.title}}</h3>
{% endfor %}
```
### With this PR

``` php
// PHP? NONE!!!!
```

``` html+django
{% for job in TimberStream('job-listings').get_posts %}
    <h3>{{job.title}}</h3>
{% endfor %}
```
