### PR TITLE
Style tweaks

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -87,25 +87,26 @@
   display: inline-block;
   padding: 10px 10px 10px 5px;
   opacity: .1;
+  margin-bottom: 25px;
   -webkit-transition: 0.2s opacity;
   -moz-transition: 0.2s opacity;
   transition: 0.2s opacity;
 }
-/* line 103, ../scss/style.scss */
+/* line 105, ../scss/style.scss */
 .stub .stub-action.pin-unpin {
   float: left;
 }
-/* line 106, ../scss/style.scss */
+/* line 108, ../scss/style.scss */
 .stub .stub-action.remove {
   float: right;
   opacity: 0;
 }
-/* line 112, ../scss/style.scss */
+/* line 114, ../scss/style.scss */
 .stub .date {
   color: #AAA;
   border: 0;
 }
-/* line 116, ../scss/style.scss */
+/* line 118, ../scss/style.scss */
 .stub .row-actions {
   opacity: 0;
   display: inline;
@@ -114,51 +115,51 @@
   -moz-transition: 0.2s opacity;
   transition: 0.2s opacity;
 }
-/* line 123, ../scss/style.scss */
+/* line 125, ../scss/style.scss */
 .stub:hover {
   background: #fafafa;
 }
-/* line 125, ../scss/style.scss */
+/* line 127, ../scss/style.scss */
 .stub:hover .row-actions {
   opacity: 1;
 }
-/* line 128, ../scss/style.scss */
+/* line 130, ../scss/style.scss */
 .stub:hover .stub-action {
   opacity: .5;
 }
-/* line 133, ../scss/style.scss */
+/* line 135, ../scss/style.scss */
 .stub.pinned {
   box-shadow: none;
 }
-/* line 136, ../scss/style.scss */
+/* line 138, ../scss/style.scss */
 .stub.pinned:hover {
   background: #e9e9e9;
 }
-/* line 139, ../scss/style.scss */
+/* line 141, ../scss/style.scss */
 .stub.pinned .pin-unpin {
   opacity: 1;
   color: #D54E21;
 }
-/* line 142, ../scss/style.scss */
+/* line 144, ../scss/style.scss */
 .stub.pinned .pin-unpin.animating {
   -webkit-animation: pulse .5s ease-out;
   animation: pulse .5s ease-out;
 }
-/* line 148, ../scss/style.scss */
+/* line 150, ../scss/style.scss */
 .stub.ui-sortable-helper {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   opacity: .9;
 }
-/* line 152, ../scss/style.scss */
+/* line 154, ../scss/style.scss */
 .stub.inserted {
   background: #FBF0C0;
 }
-/* line 155, ../scss/style.scss */
+/* line 157, ../scss/style.scss */
 .stub.removed {
   background: #FBCFCA !important;
 }
 
-/* line 167, ../scss/style.scss */
+/* line 169, ../scss/style.scss */
 .sm-alert {
   display: none;
   cursor: pointer;
@@ -168,18 +169,18 @@
   font-weight: bold;
 }
 
-/* line 185, ../scss/style.scss */
+/* line 187, ../scss/style.scss */
 .sm-add .sm-search-container {
   position: relative;
 }
-/* line 189, ../scss/style.scss */
+/* line 191, ../scss/style.scss */
 .sm-add .sm-search {
   display: block;
   width: 100%;
   padding: 10px 14px;
   margin: 0;
 }
-/* line 196, ../scss/style.scss */
+/* line 198, ../scss/style.scss */
 .sm-add .sm-results {
   padding: 5px 0;
   margin: 0;
@@ -191,60 +192,64 @@
   border-radius: 0 0 4px 4px;
   box-shadow: 0 3px 7px rgba(0, 0, 0, 0.1);
 }
-/* line 207, ../scss/style.scss */
+/* line 209, ../scss/style.scss */
 .sm-add .sm-results li {
   margin: 0;
 }
-/* line 211, ../scss/style.scss */
+/* line 213, ../scss/style.scss */
 .sm-add .sm-results .sm-result {
   text-decoration: none;
   display: block;
   padding: 6px 15px;
 }
-/* line 216, ../scss/style.scss */
+/* line 218, ../scss/style.scss */
 .sm-add .sm-results .sm-result.active {
   background: #0074A2;
   color: #FFF;
 }
-/* line 222, ../scss/style.scss */
+/* line 224, ../scss/style.scss */
 .sm-add .sm-results .sm-result-date {
   font-size: 11px;
   opacity: .5;
   margin-left: 5px;
 }
 
-/* line 237, ../scss/style.scss */
+/* line 239, ../scss/style.scss */
 .zone {
   margin: 0;
   box-shadow: none;
   min-height: 0;
   background: transparent;
 }
-/* line 242, ../scss/style.scss */
+/* line 244, ../scss/style.scss */
+.zone .stub-action {
+  margin-bottom: 0px;
+}
+/* line 247, ../scss/style.scss */
 .zone .zone-header {
   border-width: 0;
   background: transparent;
   box-shadow: none;
   margin: 6px 1px;
 }
-/* line 248, ../scss/style.scss */
+/* line 253, ../scss/style.scss */
 .zone .zone-header:focus {
   background: #FFF;
   border-width: 1px;
   margin: 5px 0;
 }
-/* line 255, ../scss/style.scss */
+/* line 260, ../scss/style.scss */
 .zone h3 {
   margin: 0;
 }
 
-/* line 261, ../scss/style.scss */
+/* line 266, ../scss/style.scss */
 .add-layout-container,
 .add-zone-container {
   display: none;
 }
 
-/* line 268, ../scss/style.scss */
+/* line 273, ../scss/style.scss */
 #stream_box_stream {
   background: transparent;
   border: 0;
@@ -252,34 +257,34 @@
   -moz-box-shadow: none;
   box-shadow: none;
 }
-/* line 274, ../scss/style.scss */
+/* line 279, ../scss/style.scss */
 #stream_box_stream > .handlediv,
 #stream_box_stream > .hndle {
   display: none;
 }
-/* line 278, ../scss/style.scss */
+/* line 283, ../scss/style.scss */
 #stream_box_stream > .inside {
   margin: 0;
   padding: 0;
 }
-/* line 282, ../scss/style.scss */
+/* line 287, ../scss/style.scss */
 #stream_box_stream > .inside > .sm-posts {
   border: 0;
 }
 
-/* line 288, ../scss/style.scss */
+/* line 293, ../scss/style.scss */
 .post-type-sm_stream #title {
   position: relative;
   z-index: 1;
 }
 
-/* line 294, ../scss/style.scss */
+/* line 299, ../scss/style.scss */
 .misc-pub-visibility,
 .misc-pub-curtime {
   display: none;
 }
 
-/* line 297, ../scss/style.scss */
+/* line 302, ../scss/style.scss */
 #misc-publishing-actions {
   padding-bottom: 15px;
 }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -98,7 +98,9 @@ $stub-pinned: #F1F1F1;
         display: inline-block;
         padding: 10px 10px 10px 5px;
         opacity: .1;
+        margin-bottom: 25px;
         @include prefixer(transition, .2s opacity);
+
 
         &.pin-unpin {
             float: left;
@@ -239,6 +241,9 @@ $stub-pinned: #F1F1F1;
     box-shadow: none;
     min-height: 0;
     background: transparent;
+    .stub-action {
+        margin-bottom: 0px;
+    }
     .zone-header {
         border-width: 0;
         background: transparent;

--- a/includes/views/stub.twig
+++ b/includes/views/stub.twig
@@ -10,9 +10,11 @@
 		{% endif %}
 
 		<a class="stub-title row-title" href="{{ post.edit_link }}" title="Edit Post" target="_blank">{{ post.title }}</a>
+		{#
 		<div class="post-intro">
 			{{post.get_preview(10, true, '')}}
 		</div>
+		#}
 		<div class="post-meta">
 			<abbr title="{{ post.post_date }}" class="date">
 			{{ function('human_time_diff', function('strtotime', post.post_date)) }} ago


### PR DESCRIPTION
Hi Chris,

I made some style tweaks to
- Consistent height of stubs (ones with images were taller, which made the ones without seem weird)
- Right align images (this way the left side is always on the same X-axis whether-or-not there's an image)
- Make image thumbnails wider (approx 4x3)
- De-emphasize pinned appearance (right now the pin turns red, the background changes and the title color changes). This calls too much attention to these posts. I have it so the pin just turns red, which seems sufficient to distinguish these

Here's a preview of what this looks like:

![screen shot 2014-10-09 at 11 44 44 am](https://cloud.githubusercontent.com/assets/1298086/4579307/bb5473d0-4fcb-11e4-8a08-eede3c2d140d.png)
