### PR TITLE
created factory class to deal with making new stream programmatically

### DIFF
--- a/includes/class-stream-manager-factory.php
+++ b/includes/class-stream-manager-factory.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * StreamManagerFactory.
+ *
+ * This makes streams programatically instead of via the admin
+ *
+ * @package  StreamManager
+ * @author   Chris Voll + Jared Novack + Upstatement
+ * @link   http://upstatement.com
+ * @copyright 2014 Upstatement
+ */
+
+class StreamManagerFactory {
+
+	var $slug;
+	var $plugin = null;
+
+	function __construct( $slug ) {
+		$this->slug = $slug;
+		$this->plugin = StreamManager::get_instance();
+		add_action( 'admin_init', array( $this, 'create_post' ) );
+	}
+
+	function does_stream_exist( $slug ) {
+		$streams = $this->plugin->get_streams( array( 'name' => $slug ) );
+		if ( count( $streams ) && is_array( $streams ) ) {
+			return $streams[0];
+		}
+	}
+
+	function create_post( ) {
+		$stream = $this->does_stream_exist( $this->slug );
+		if ( $stream ) {
+			$this->ID = $stream->ID;
+			return;
+		}
+
+		$post_data = array( 'post_type' => $this->plugin->get_post_type_slug(), 'post_name' => $this->slug, 'post_status' => 'publish' );
+		$post = wp_insert_post( $post_data );
+		$this->ID = $post->ID;
+
+	}
+
+	function set_post_type( $post_type ) {
+		add_filter( 'stream-manager/options/slug='.$this->slug, function( $options, $stream ) use ( $post_type ) {
+				$options['query']['post_type'] = $post_type;
+				return $options;
+			}, 10, 2 );
+	}
+
+	function set_labels( $labels ) {
+		add_action( 'admin_init', function() use ( $labels ) {
+				if ( is_string( $labels ) ) {
+					wp_update_post( array( 'ID' => $this->ID, 'post_title' => $labels ) );
+				}
+			}, 11 );
+
+	}
+
+}

--- a/includes/class-stream-manager.php
+++ b/includes/class-stream-manager.php
@@ -68,7 +68,6 @@ class StreamManager {
 	 * @since     1.0.0
 	 */
 	private function __construct() {
-
 		// Ensure that Timber is loaded
 		if ( !self::check_dependencies() ) return;
 		require_once( plugin_dir_path( __FILE__ ) . 'timber-stream.php' );
@@ -162,7 +161,7 @@ class StreamManager {
 	    'show_in_menu'        => true,
 	    'show_in_nav_menus'   => false,
 	    'show_in_admin_bar'   => false,
-	    'menu_position'       => 5,
+	    'menu_position'       => 25,
 	    'menu_icon'           => 'dashicons-list-view',
 	    'can_export'          => true,
 	    'has_archive'         => false,

--- a/includes/timber-stream.php
+++ b/includes/timber-stream.php
@@ -82,7 +82,9 @@ class TimberStream extends TimberPost {
 
     if ( !$this->post_content ) $this->post_content = serialize(array());
     $this->options = array_merge( $this->default_options, unserialize($this->post_content) );
+    $this->options = apply_filters( 'stream-manager/options/slug='.$this->slug, $this->options, $this );
     $this->options = apply_filters( 'stream-manager/options/id=' . $this->ID, $this->options, $this );
+
   }
 
   /**

--- a/stream-manager.php
+++ b/stream-manager.php
@@ -52,7 +52,9 @@ if ( !class_exists('Timber') ) {
 ////////////////////////////////////////////
 
 require_once( plugin_dir_path( __FILE__ ) . 'includes/class-stream-manager.php' );
+require_once( plugin_dir_path( __FILE__ ) . 'includes/class-stream-manager-factory.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'includes/timber-stream.php' );
+
 
 add_action( 'plugins_loaded', array( 'StreamManager', 'get_instance' ) );
 
@@ -67,4 +69,14 @@ if ( is_admin() ) {
 	require_once( plugin_dir_path( __FILE__ ) . 'includes/class-stream-manager-admin.php' );
   
 	add_action( 'plugins_loaded', array( 'StreamManagerAdmin', 'get_instance' ) );
+}
+
+function register_stream($slug, $args) {
+    $factory = new StreamManagerFactory($slug);
+    if (isset($args['post_type'])) {
+      $factory->set_post_type($args['post_type']);
+    }
+    if (isset($args['label'])) {
+      $factory->set_labels($args['label']);
+    }
 }


### PR DESCRIPTION
This allows a dev to create a stream programatically. The main interface for this is...

``` php
register_stream('homepage', array(
            'post_type' => array('article', 'list'),
            'label' => 'Main Page',
            ));
```

I decided to follow WP's convention of `register_post_type`, `register_taxonomy`, etc. The definition of the function is...

``` php
register_stream( $slug, $options = array() );
```

This makes it much easier to define theme-level streams for inclusion
