### PR TITLE
Closes #23

### DIFF
--- a/includes/timber-stream.php
+++ b/includes/timber-stream.php
@@ -106,6 +106,10 @@ class TimberStream extends TimberPost {
     foreach ( $this->get('stream') as $item ) {
       $query['post__in'][] = $item['id'];
     }
+    if( isset( $query['post__not_in'] ) && is_array( $query['post__not_in'] ) ){
+      $query['post__in'] = array_diff( $query['post__in'], $query['post__not_in'] );
+      unset( $query['post__not_in'] );
+    }
 
     // Remove any taxonomy limitations, since those would remove any
     // posts from the stream that were added by searching in the UI.


### PR DESCRIPTION
If the `post__not_in` parameter is present in the passed `$query`, this change strips the contained post IDs from the `post__in` parameter, effectively honoring the `post__not_in` parameter.
