### PR TITLE
Allow data to be saved for the original post being edited

### DIFF
--- a/includes/class-stream-manager-admin.php
+++ b/includes/class-stream-manager-admin.php
@@ -407,6 +407,12 @@ class StreamManagerAdmin {
 		}
 
 		if ( $old != 'publish' && $new == 'publish' ) {
+			//seems weird, but it's necessary for ACF
+			//and potentially other plugins
+			//we can't be sure what actions have been added
+			//so checking for infinite loop-type bugs isn't possible
+			do_action('save_post', $post->ID, $post, true );
+			remove_all_actions('save_post');
 			// Add to streams
 			$streams = $this->plugin->get_streams();
 			foreach ( $streams as $stream ) {


### PR DESCRIPTION
Closes #26

This is caused by the wonderful complexity of action hooks:
- ACF adds a hook onto the `save_post` action in order to update all ACF data. Makes sense.
- Stream Manager adds a hook onto `transition_post_status`, which is fired _before_ `save_post` is.
- Stream Manager's callback, `on_save_post` calls the Stream's `insert_post` method, which happens to make a call to `wp_update_post`, whiiich happens to fire `save_post`. _Whew_
- This causes ACF to pick up on the `save_post` hook that is then fired (currently for the stream, _not_ the original post being edited.
- During ACF's `save_post` callback(s), it checks for the presence of an ACF generated nonce. If it finds it, it actually modifies the `$_POST` array and sets it to false.
- When `save_post` is fired for the post actually being edited, and not the stream, the `$_POST`array no longer contains a valid nonce, so ACF bails.

This PR is a bit of a hacky way to get around that - in Stream Manager's `transition_post_status` method, it takes the liberty of firing `save_post` _before_ any calls are made to `wp_update_post` so that other actions have a chance to work with the original post being edited. It then removes all currently set actions for the `save_post` callback so they aren't fired twice.
