### PR TITLE
Add visual limit to number of stories in Stream interface

### DIFF
--- a/includes/class-stream-manager-admin.php
+++ b/includes/class-stream-manager-admin.php
@@ -138,7 +138,19 @@ class StreamManagerAdmin {
 			array(),
 			StreamManager::VERSION
 		);
-	}
+
+		/*
+		 * this limits the number of visible stream items via css
+		 * when one is deleted, the stubs "move up", so they one at a time become visible
+		 * https://github.com/Upstatement/stream-manager/issues/28
+		 */
+		//+ 1 because css is greedy! (it encompasses the number, so we want the *next* element)
+		$display_limit = (int) apply_filters( $this->plugin_slug . '_stub_display_limit', 15 ) + 1;
+		$display_limit_css = ".sm-posts .stub:nth-child(n+{$display_limit}){
+			display:none;
+		}";
+		wp_add_inline_style( $this->plugin_slug .'-admin-styles', $display_limit_css );
+	 }
 
 	/**
 	 * Register and enqueue admin-specific JavaScript.


### PR DESCRIPTION
Towards #28
Since objects are removed from the dom when the "x" is clicked, a simple css selector can encompass the visual requirements of this enhancement.

What is _not_ covered is the case when the number of posts left in the entire stream are less than or equal to the `stream-manager_stub_display_limit` _before_ the "x" is clicked. If that happens, there is no post to take it's place. I assume this is intended behavior, but if the intention is to have the empty spot automatically/immediately populated by querying for a new post, let me know @jarednova and I'll tackle that.
