### PR TITLE
Added filter to fix yoast premium conflict

### DIFF
--- a/includes/timber-stream.php
+++ b/includes/timber-stream.php
@@ -379,17 +379,27 @@ class TimberStream extends TimberPost {
   }
 
 
+
   /**
    * Save the stream metadata
    *
    * @since     1.0.0
    */
+
+  
   public function save_stream() {
     $save_data = apply_filters( 'stream-manager/save/id=' . $this->ID, array(
       'ID' => $this->ID,
       'post_content' => serialize($this->options)
     ), $this);
+
+    // Fix conflict with yoast premium
+    add_filter('wpseo_premium_post_redirect_slug_change', '__return_true');
+    
     wp_update_post( $save_data );
+
+    remove_filter('wpseo_premium_post_redirect_slug_change', '__return_true');
+
   }
 
 }


### PR DESCRIPTION
Hey so this isn't quite what we originally talked about.  Turned out that removing/re-adding all of the functions from the hook was going to be pretty complicated.   But the instance we're dealing with seems like an edge case, and using this filter from Yoast should prevent the redirect issue from coming up again on the nejm site and anywhere else where we use sm and wpseo-premium together.  I worked through this with Mike B, and I think it's the best way to go.  But let me know if you have questions/concerns!
