### PR TITLE
Set up SM to work with Timber installed directly in the theme via composer

### DIFF
--- a/stream-manager.php
+++ b/stream-manager.php
@@ -36,16 +36,26 @@ if ( ! defined( 'WPINC' ) ) die;
 // Check if Timber is installed, and include it before any stream manager
 // things are initiated. This is needed for the TimberStream class.
 if ( !class_exists('Timber') ) {
-  if ( !is_dir( plugin_dir_path(__DIR__).'timber-library' ) && !is_dir( plugin_dir_path(__DIR__).'timber' ) ) {
+
+  // WP plugin repo version
+  if ( is_dir( plugin_dir_path(__DIR__).'timber-library') ) {
+    include_once( plugin_dir_path(__DIR__).'timber-library/timber.php' );
+  } 
+  // old development copy
+  elseif( is_dir( plugin_dir_path(__DIR__).'timber' ) ) {
+    include_once( plugin_dir_path(__DIR__).'timber/timber.php' );
+  } 
+  // included directly in the theme via composer
+  elseif ( is_dir( get_template_directory() . '/vendor/timber' ) ) {
+    include_once( get_template_directory() . '/vendor/autoload.php');
+  } 
+
+  // Timber is nowhere to be found, throw a notice and return
+  else {
     add_action('admin_notices', function() {
       echo('<div class="error"><p>Please install <a href="http://upstatement.com/timber/">Timber</a> to use Stream Manager.</p></div>');
     });
-  } else {
-  	if(is_dir( plugin_dir_path(__DIR__).'timber-library')) {
-  		include_once( plugin_dir_path(__DIR__).'timber-library/timber.php' );
-  	} else {
-  		include_once( plugin_dir_path(__DIR__).'timber/timber.php' );
-  	}
+    return;
   }
 } 
 


### PR DESCRIPTION
It's now possible to install Timber directly in a theme via Composer than in the plugins directory.  This adds logic to check for Timber in the vendor, and if so include the composer autoload file.