### PR TITLE
#56 Apply filters to 'Add Post' search results

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -564,7 +564,8 @@ jQuery(function($) {
 
             var request = {
               action: 'sm_search',
-              query: that.search_query
+              query: that.search_query,
+              stream_id: $('#post_ID').val()
             };
 
             $.post(ajaxurl, request, function(results) {

--- a/includes/class-stream-manager-admin.php
+++ b/includes/class-stream-manager-admin.php
@@ -420,8 +420,8 @@ class StreamManagerAdmin {
 	 * @param     array   $request   AJAX request (uses $_POST instead)
 	 */
 	public function ajax_search_posts( $request ) {
-		if ( !isset( $_POST['query'] ) ) $this->ajax_respond( 'error' );
-		$output = StreamManagerAjaxHelper::search_posts($_POST['query']);
+		if ( !isset( $_POST['query'] ) || !isset( $_POST['stream_id'] ) ) $this->ajax_respond( 'error' );
+		$output = StreamManagerAjaxHelper::search_posts($_POST['query'], $_POST['stream_id']);
 
 		$this->ajax_respond( 'success', $output );
 	}

--- a/includes/class-stream-manager-ajax-helper.php
+++ b/includes/class-stream-manager-ajax-helper.php
@@ -48,16 +48,21 @@ class StreamManagerAjaxHelper {
 	 * @since     1.0.0
 	 *
 	 * @param     string   $query  search term
+	 * @param 	  int      $stream_id  post id of current stream
 	 *
 	 * @return    array   $output  posts w/ ids, date, title, human time diff 
 	 */
-	public static function search_posts($query) {
-		$posts = Timber::get_posts(array(
+	public static function search_posts( $query, $stream_id ) {
+		$defaults = array(
 			's' => $query,
 			'post_type' => 'post',
 			'post_status' => 'publish',
 			'posts_per_page' => 10
-		));
+		);
+		$stream = new TimberStream($stream_id);
+		$args = array_merge( $defaults, $stream->get( 'query' ) );
+
+		$posts = Timber::get_posts( $args );
 
 		$output = array();
 

--- a/tests/StreamManager_UnitTestCase.php
+++ b/tests/StreamManager_UnitTestCase.php
@@ -11,8 +11,12 @@
 			return $post_ids;
 		}
 
-		public function buildStream() {
-			$pid = $this->factory->post->create(array('post_type' => 'sm_stream', 'post_content' => '', 'post_title' => 'Sample Stream'));
+		function buildStream( $name = 'Sample Stream', $options = array() ) {
+			$pid = $this->factory->post->create(array('post_type' => 'sm_stream', 'post_content' => '', 'post_title' => $name));
+			add_filter('stream-manager/options/id='.$pid, function($defaults, $stream) use ($options) {
+				$defaults['query'] = array_merge($defaults['query'], $options);
+				return $defaults;
+			}, 10, 2);
 			$stream = new TimberStream($pid);
 			return $stream;
 		}

--- a/tests/test-stream-manager-ajax-helper.php
+++ b/tests/test-stream-manager-ajax-helper.php
@@ -30,19 +30,29 @@
 		}
 
 		function testSearchPosts() {
+			$pid = $this->buildStream();
 			$bagel_post = $this->factory->post->create(array('post_title' => 'Bagels'));
 			$croissant_post = $this->factory->post->create(array('post_title' => 'Croissants'));
 			$pastries_post = $this->factory->post->create(array('post_title' => 'Croissants and Bagels'));
-			$output = StreamManagerAjaxHelper::search_posts('bagel');
+			$output = StreamManagerAjaxHelper::search_posts('bagel', $pid);
 			$this->assertEquals(2, count($output));
 			$this->assertEquals('1 min', $output[0]['human_date']);
 		}
 
-		function testSearchPostsNoMatches() {
-			$bagel_post = $this->factory->post->create(array('post_title' => 'Bagels'));
-			$output = StreamManagerAjaxHelper::search_posts('muffin');
-			$this->assertEquals(0, count($output));
+		function testSearchPostsAppliesFilter() {
+			$pid = $this->buildStream('Test Stream', array('post_type' => 'pastry'));
+			$this->factory->post->create(array('post_title' => 'bagel1'));
+			$this->factory->post->create(array('post_title' => 'bagel2'));
+			$this->factory->post->create(array('post_title' => 'bagel3', 'post_type' => 'pastry'));
+			$output = StreamManagerAjaxHelper::search_posts('bagel', $pid);
+			$this->assertEquals(1, count($output));
 		}
 
+		function testSearchPostsNoMatches() {
+			$pid = $this->buildStream();
+			$bagel_post = $this->factory->post->create(array('post_title' => 'Bagels'));
+			$output = StreamManagerAjaxHelper::search_posts('muffin', $pid);
+			$this->assertEquals(0, count($output));
+		}
 
 	}

--- a/tests/test-stream-manager-hooks.php
+++ b/tests/test-stream-manager-hooks.php
@@ -2,16 +2,6 @@
 
 	class TestStreamManagerHooks extends StreamManager_UnitTestCase {
 
-		function buildStream( $name = 'Sample Stream', $options = array() ) {
-			$pid = $this->factory->post->create(array('post_type' => 'sm_stream', 'post_content' => '', 'post_title' => $name));
-			add_filter('stream-manager/options/id='.$pid, function($defaults, $stream) use ($options) {
-				$defaults['query'] = array_merge($defaults['query'], $options);
-				return $defaults;
-			}, 10, 2);
-			$stream = new TimberStream($pid);
-			return $stream;
-		}
-
 		function testQueryHook() {
 			$stream = $this->buildStream('Sample Stream', array('post_type' => 'article'));
 			$this->buildPosts(5);


### PR DESCRIPTION
This edit makes it so any filters applied to a stream will also be applied to the search results retrieved from the 'Add Post' metabox, addresses #57.