### PR TITLE
Added call to Timber constructor to fix aliasing error

### DIFF
--- a/stream-manager.php
+++ b/stream-manager.php
@@ -47,6 +47,9 @@ if ( !class_exists('Timber') ) {
   // included directly in the theme via composer
   elseif ( is_dir( get_template_directory() . '/vendor/timber' ) ) {
     include_once( get_template_directory() . '/vendor/autoload.php');
+
+    // initialize Timber class to run backwards compatibility methods
+    new Timber\Timber();
   } 
 
   // Timber is nowhere to be found, throw a notice and return


### PR DESCRIPTION
Fixes backwards compatibility error from the aliased `TimberPost` class (only applies to when Timber is installed as a php dependency via composer). 